### PR TITLE
Add support for AGP 8.0 on the release branch

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,6 +45,7 @@ android {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
+    namespace 'com.builttoroam.devicecalendar'
 }
 
 dependencies {


### PR DESCRIPTION
* Fix: Add namespace to the release version for compatibility whit AGP 8.0+ (Fixes #523 #527)

Co-authored-by: ashwani <ashwani@users.noreply.github.com>